### PR TITLE
Fix last report getting duplicated when pen is OOR

### DIFF
--- a/DevocubFilters/AntiChatter.cs
+++ b/DevocubFilters/AntiChatter.cs
@@ -153,14 +153,13 @@ namespace TabletDriverFilters.Devocub
 
         protected override void UpdateState()
         {
-            if (State is ITabletReport report)
+            if (State is ITabletReport report && PenIsInRange())
             {
                 report.Position = Filter(calcTarget) / MillimeterScale;
                 report.Pressure = this.pressure;
                 State = report;
 
-                if (PenIsInRange())
-                    OnEmit();
+                OnEmit();
             }
         }
 

--- a/DevocubFilters/AntiChatter.cs
+++ b/DevocubFilters/AntiChatter.cs
@@ -145,6 +145,10 @@ namespace TabletDriverFilters.Devocub
                 else
                     calcTarget = targetPos;
             }
+            else
+            {
+                OnEmit();
+            }
         }
 
         protected override void UpdateState()
@@ -154,11 +158,9 @@ namespace TabletDriverFilters.Devocub
                 report.Position = Filter(calcTarget) / MillimeterScale;
                 report.Pressure = this.pressure;
                 State = report;
-            }
 
-            if (PenIsInRange() || State is not ITabletReport)
-            {
-                OnEmit();
+                if (PenIsInRange())
+                    OnEmit();
             }
         }
 

--- a/HawkuFilters/Smoothing.cs
+++ b/HawkuFilters/Smoothing.cs
@@ -37,6 +37,8 @@ namespace TabletDriverFilters.Hawku
         {
             if (State is ITabletReport report)
                 this.targetPos = new Vector3(report.Position, report.Pressure) * mmScale;
+            else
+                OnEmit();
         }
 
         protected override void UpdateState()
@@ -47,10 +49,10 @@ namespace TabletDriverFilters.Hawku
                 report.Position = new Vector2(newPoint.X, newPoint.Y);
                 report.Pressure = (uint)newPoint.Z;
                 State = report;
-            }
 
-            if (PenIsInRange() || State is not ITabletReport)
-                OnEmit();
+                if (PenIsInRange())
+                    OnEmit();
+            }
         }
 
         public Vector3 Filter(Vector3 point)

--- a/HawkuFilters/Smoothing.cs
+++ b/HawkuFilters/Smoothing.cs
@@ -43,15 +43,14 @@ namespace TabletDriverFilters.Hawku
 
         protected override void UpdateState()
         {
-            if (State is ITabletReport report)
+            if (State is ITabletReport report && PenIsInRange())
             {
                 var newPoint = Filter(this.targetPos) / mmScale;
                 report.Position = new Vector2(newPoint.X, newPoint.Y);
                 report.Pressure = (uint)newPoint.Z;
                 State = report;
 
-                if (PenIsInRange())
-                    OnEmit();
+                OnEmit();
             }
         }
 


### PR DESCRIPTION
## Reproduction

- Install and use Windows Ink output mode plugin.
- Use either Hawku smoothing or Devocub antichatter.
- Move pen
- Release pen
- Move mouse
- Mouse should be locked now

Provided sample plugins built using this PR for easier repro:
- [HawkuFilters](https://github.com/OpenTabletDriver/TabletDriverFilters/files/11533139/HawkuFilters.zip)
- [DevocubFilters](https://github.com/OpenTabletDriver/TabletDriverFilters/files/11533142/DevocubFilters.zip)

## Why?

It is now locked due to the OS cursor sync feature of windows ink output mode that happens on `ISynchronousPointer.Reset()`. It's expected that this interface be only called once when a pointer is leaving. However due to how the interpolators here are coded, it's actually saving the OOR report into `State` and then sends it later via `OnEmit()` every timer tick. This effectively makes windows ink output mode synchronize the OS cursor every timer tick.

## The Fix

We should only ever emit asynchronous reports when the latest report is actually a `ITabletReport` and emit every thing else synchronously.